### PR TITLE
Generate sudoku puzzles and pdf

### DIFF
--- a/sudoku_printer.py
+++ b/sudoku_printer.py
@@ -97,8 +97,8 @@ class SudokuPrinter:
             defaults = self.default_settings[size]
             cell_size = options.get('cell_size', defaults['cell_size'])
             font_size = options.get('font_size', defaults['font_size'])
-            solution_cell_size = options.get('solution_cell_size', defaults['solution_cell_size'])
-            solution_font_size = options.get('solution_font_size', defaults['solution_font_size'])
+            solution_cell_size = options.get('solution_cell_size') or defaults['solution_cell_size']
+            solution_font_size = options.get('solution_font_size') or defaults['solution_font_size']
             
             # Determine box separator positions
             if size == 4:

--- a/sudoku_printer.py
+++ b/sudoku_printer.py
@@ -324,8 +324,8 @@ class SudokuPrinter:
         default_cell_size = self.default_settings[first_size]['cell_size']
         default_font_size = self.default_settings[first_size]['font_size']
         
-        cell_size = options.get('cell_size', default_cell_size)
-        font_size = options.get('font_size', default_font_size)
+        cell_size = options.get('cell_size') or default_cell_size
+        font_size = options.get('font_size') or default_font_size
         title_font_size = options.get('title_font_size', 14)
         puzzle_margin = options.get('puzzle_margin', 10)
         


### PR DESCRIPTION
Update `SudokuPrinter` to correctly use default formatting options when `None` is passed.

This fixes a `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'` that occurred when optional command-line arguments like `--cell-size` were not provided. Previously, `options.get(key, default)` would return `None` if the value for `key` was explicitly `None`, instead of falling back to the `default`. The change to `options.get(key) or default` ensures the default is used in such cases.